### PR TITLE
Fixed `java.lang.IllegalStateException: ViewHolder views must not be attached when created. `

### DIFF
--- a/stickyheaders/src/main/java/org/zakariya/stickyheaders/SectioningAdapter.java
+++ b/stickyheaders/src/main/java/org/zakariya/stickyheaders/SectioningAdapter.java
@@ -267,6 +267,7 @@ public class SectioningAdapter extends RecyclerView.Adapter<SectioningAdapter.Vi
 	 */
 	public GhostHeaderViewHolder onCreateGhostHeaderViewHolder(ViewGroup parent) {
 		View ghostView = new View(parent.getContext());
+		ghostView.setLayoutParams(new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
 		return new GhostHeaderViewHolder(ghostView);
 	}
 


### PR DESCRIPTION
Added this workaround https://github.com/ShamylZakariya/StickyHeaders/issues/87#issuecomment-369088743